### PR TITLE
Fix for extreme nameservers amount on zone creation using nameserver_type argument

### DIFF
--- a/internal/cloudns/resource_dns_zone.go
+++ b/internal/cloudns/resource_dns_zone.go
@@ -79,7 +79,6 @@ func resourceDnsZoneCreate(ctx context.Context, d *schema.ResourceData, meta int
 	zoneToCreate := toApiZone(d)
 
 	// Determine (and eventually sort) NS records
-	var ns []string
 	_, nsExist := d.GetOk("nameservers")
 	_, nstExist := d.GetOk("nameserver_type")
 	if nsExist || nstExist {
@@ -93,10 +92,10 @@ func resourceDnsZoneCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	if len(ns) == 0 {
+	if len(zoneToCreate.Ns) == 0 {
 		tflog.Debug(ctx, fmt.Sprintf("CREATE DNS zone: %s, type: %s", resp.Domain, resp.Ztype))
 	} else {
-		tflog.Debug(ctx, fmt.Sprintf("CREATE DNS zone: %s, type: %s, ns: %s", resp.Domain, resp.Ztype, strings.Join(ns, ", ")))
+		tflog.Debug(ctx, fmt.Sprintf("CREATE DNS zone: %s, type: %s, ns: %s", resp.Domain, resp.Ztype, strings.Join(zoneToCreate.Ns, ", ")))
 	}
 
 	d.SetId(zoneToCreate.Domain)

--- a/internal/cloudns/resource_dns_zone.go
+++ b/internal/cloudns/resource_dns_zone.go
@@ -226,6 +226,7 @@ func getNsNames(d *schema.ResourceData, nsList []cloudns.Ns) []string {
 		for _, rec := range ns.([]interface{}) {
 			rns = append(rns, rec.(string))
 		}
+		rns = sortNsNames(rns)
 		return slices.CompactFunc(rns, strings.EqualFold)
 	}
 
@@ -242,8 +243,8 @@ func getNsNames(d *schema.ResourceData, nsList []cloudns.Ns) []string {
 	}
 
 	// we compact and sort NS records to avoid creating diffs should there be changes in the API response
-	fns = slices.CompactFunc(fns, strings.EqualFold)
 	fns = sortNsNames(fns)
+	fns = slices.CompactFunc(fns, strings.EqualFold)
 
 	return fns
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a crucial fix to a bug introduced when implementing the new feature to specify nameservers or nameserver type in #12.


## Motivation for this PR

The bug mentioned below.


## What is the current behavior?

When adding nameservers by type, the nameserver list was compacted prior to sorting the list, meaning the compacting didn't function properly.
As a consequence a ridiculous amount of NS records would be added when creating a new zone using the `nameserver_type` argument on `cloudns_dns_zone` resources.


## What is the new behavior

This fix will ensure that the nameservers list is sorted before compacting, ensuring a unique list of entries.


## Does this PR introduce a breaking change?

No.