### PR TITLE
Remove superflous Update function

### DIFF
--- a/internal/cloudns/resource_dynamic_url.go
+++ b/internal/cloudns/resource_dynamic_url.go
@@ -16,7 +16,6 @@ func resourceDynamicUrl() *schema.Resource {
 
 		CreateContext: resourceDynamicUrlGetOrCreate,
 		ReadContext:   resourceDynamicUrlGetOrCreate,
-		UpdateContext: resourceDynamicUrlGetOrCreate,
 		DeleteContext: resourceDynamicUrlDelete,
 
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
OpenTofu was complaining that an Update function makes no sense if all properties are ForceNew or Computed.
Checked the docs and it is indeed optional, so removing it as it is useless.

In fact it upsets OpenTofu so much it errors out.

OpenTofu logs:
```
│ Error: InternalValidate
│
│   with provider["registry.opentofu.org/cloudns/cloudns"],
│   on provider["registry.opentofu.org/cloudns/cloudns"] with no configuration line 1:
│   (source code not available)
│
│ Internal validation of the provider failed! This is always a bug
│ with the provider itself, and not a user issue. Please report
│ this bug:
│
│ resource cloudns_dynamic_url: All fields are ForceNew or Computed w/out Optional, Update is superfluous
```